### PR TITLE
Fixes double rendering of analog clocks by clearing the context

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -41,7 +41,7 @@
                       </div>
                     </div>
                     <h2 class="text-center" id="time"></h2>
-                    
+
                   </div>
                 </div>
               </div>
@@ -56,112 +56,109 @@
               </div>
               <hr>
               <div class="row">
-                <div class="row">
-  <div class="col-sm-6 col-md-4">
-  <div class="panel panel-default text-center">
-    <div class="panel-heading">
-      <h1 >Fajr - الفجر</h1>
-    </div>
-    <div class="panel-body" >
-      <div>
-        <h2 id="i_fajr"></h2>
-        <canvas id="canvas_fajr" width="350" height="350">
-        </canvas>
-      </div>
-      
-        <h3 id="t_fajr"></h3>
-        
-    </div>
-  </div>
-</div>
-<div class="col-sm-6 col-md-4">
-  <div class="panel panel-default text-center">
-    <div class="panel-heading">
-      <h1 >Sunrise - الشروق</h1>
-    </div>
-    <div class="panel-body" >
-      <div>
-        <h2 id="t_sunrise"></h2>
-        <canvas id="canvas_sunrise" width="350" height="350">
-        </canvas>
-      </div>
-      
-        
-    </div>
-  </div>
-</div>
-<div class="col-sm-6 col-md-4">
-  <div class="panel panel-default text-center">
-    <div class="panel-heading">
-      <h1 >Dhuhr - الظهر</h1>
-    </div>
-    <div class="panel-body" >
-      <div>
-        <h2 id="i_dhuhr"></h2>
-        <canvas id="canvas_dhuhr" width="350" height="350">
-        </canvas>
-      </div>
-      
-        <h3 id="t_dhuhr"></h3>
-        
-    </div>
-  </div>
-</div>
-<div class="col-sm-6 col-md-4">
-  <div class="panel panel-default text-center">
-    <div class="panel-heading">
-      <h1 >Asr - العصر</h1>
-    </div>
-    <div class="panel-body" >
-      <div>
-        <h2 id="i_asr"></h2>
-        <canvas id="canvas_asr" width="350" height="350">
-        </canvas>
-      </div>
-      
-        <h3 id="t_asr"></h3>
-        
-    </div>
-  </div>
-</div>
-<div class="col-sm-6 col-md-4">
-  <div class="panel panel-default text-center">
-    <div class="panel-heading">
-      <h1 >Maghrib - المغرب</h1>
-    </div>
-    <div class="panel-body" >
-      <div>
-        <h2 id="i_maghrib"></h2>
-        <canvas id="canvas_maghrib" width="350" height="350">
-        </canvas>
-      </div>
-      
-        <h3 id="t_maghrib"></h3>
-        
-    </div>
-  </div>
-</div>
-<div class="col-sm-6 col-md-4">
-  <div class="panel panel-default text-center">
-    <div class="panel-heading">
-      <h1 >Isha - العشاء</h1>
-    </div>
-    <div class="panel-body" >
-      <div>
-        <h2 id="i_isha"></h2>
-        <canvas id="canvas_isha" width="350" height="350">
-        </canvas>
-      </div>
-      
-        <h3 id="t_isha"></h3>
-        
-    </div>
-  </div>
-</div>
-</div>
-                
+                <div class="col-sm-6 col-md-4">
+                  <div class="panel panel-default text-center">
+                    <div class="panel-heading">
+                      <h1 >Fajr - الفجر</h1>
+                    </div>
+                    <div class="panel-body" >
+                      <div>
+                        <h2 id="i_fajr"></h2>
+                        <canvas id="canvas_fajr" width="350" height="350">
+                        </canvas>
+                      </div>
+
+                        <h3 id="t_fajr"></h3>
+
+                    </div>
+                  </div>
+                </div>
+                <div class="col-sm-6 col-md-4">
+                  <div class="panel panel-default text-center">
+                    <div class="panel-heading">
+                      <h1 >Sunrise - الشروق</h1>
+                    </div>
+                    <div class="panel-body" >
+                      <div>
+                        <h2 id="t_sunrise"></h2>
+                        <canvas id="canvas_sunrise" width="350" height="350">
+                        </canvas>
+                      </div>
+
+
+                    </div>
+                  </div>
+                </div>
+                <div class="col-sm-6 col-md-4">
+                  <div class="panel panel-default text-center">
+                    <div class="panel-heading">
+                      <h1 >Dhuhr - الظهر</h1>
+                    </div>
+                    <div class="panel-body" >
+                      <div>
+                        <h2 id="i_dhuhr"></h2>
+                        <canvas id="canvas_dhuhr" width="350" height="350">
+                        </canvas>
+                      </div>
+
+                        <h3 id="t_dhuhr"></h3>
+
+                    </div>
+                  </div>
+                </div>
+                <div class="col-sm-6 col-md-4">
+                  <div class="panel panel-default text-center">
+                    <div class="panel-heading">
+                      <h1 >Asr - العصر</h1>
+                    </div>
+                    <div class="panel-body" >
+                      <div>
+                        <h2 id="i_asr"></h2>
+                        <canvas id="canvas_asr" width="350" height="350">
+                        </canvas>
+                      </div>
+
+                        <h3 id="t_asr"></h3>
+
+                    </div>
+                  </div>
+                </div>
+                <div class="col-sm-6 col-md-4">
+                  <div class="panel panel-default text-center">
+                    <div class="panel-heading">
+                      <h1 >Maghrib - المغرب</h1>
+                    </div>
+                    <div class="panel-body" >
+                      <div>
+                        <h2 id="i_maghrib"></h2>
+                        <canvas id="canvas_maghrib" width="350" height="350">
+                        </canvas>
+                      </div>
+
+                        <h3 id="t_maghrib"></h3>
+
+                    </div>
+                  </div>
+                </div>
+                <div class="col-sm-6 col-md-4">
+                  <div class="panel panel-default text-center">
+                    <div class="panel-heading">
+                      <h1 >Isha - العشاء</h1>
+                    </div>
+                    <div class="panel-body" >
+                      <div>
+                        <h2 id="i_isha"></h2>
+                        <canvas id="canvas_isha" width="350" height="350">
+                        </canvas>
+                      </div>
+
+                        <h3 id="t_isha"></h3>
+
+                    </div>
+                  </div>
+                </div>
               </div>
-              
+
             </div>
           </div>
         </div>

--- a/public/js/clock.js
+++ b/public/js/clock.js
@@ -1,81 +1,83 @@
-function clock(canvas, hour, minute){
-// var canvas = document.getElementById("canvas");
-var ctx = canvas.getContext("2d");
-var radius = canvas.height / 2;
-ctx.translate(radius, radius);
-radius = radius * 0.90
+function Clock(canvas, hour, minute) {
 
-drawClock(hour, minute);
-function drawClock(hour, minute) {
-  drawFace(ctx, radius);
-  drawNumbers(ctx, radius);
-  drawTime(ctx, radius, hour, minute);
+  this._canvas = canvas;
+  this._hour   = hour % 12;
+  this._minute = minute;
+  this._ctx    = canvas.getContext('2d');
+  this._radius  = canvas.height / 2;
+
+  this.init();
 }
 
-function drawFace(ctx, radius) {
-  var grad;
-  ctx.beginPath();
-  ctx.arc(0, 0, radius, 0, 2*Math.PI);
-  ctx.fillStyle = 'white';
-  ctx.fill();
-  grad = ctx.createRadialGradient(0,0,radius*0.95, 0,0,radius*1.05);
-  grad.addColorStop(0, '#333');
-  grad.addColorStop(0.5, 'white');
-  grad.addColorStop(1, '#333');
-  ctx.strokeStyle = grad;
-  ctx.lineWidth = radius*0.1;
-  ctx.stroke();
-  ctx.beginPath();
-  ctx.arc(0, 0, radius*0.1, 0, 2*Math.PI);
-  ctx.fillStyle = '#333';
-  ctx.fill();
-}
+Clock.prototype = {
 
-function drawNumbers(ctx, radius) {
-  var ang;
-  var num;
-  ctx.font = radius*0.15 + "px arial";
-  ctx.textBaseline="middle";
-  ctx.textAlign="center";
-  for(num = 1; num < 13; num++){
-    ang = num * Math.PI / 6;
-    ctx.rotate(ang);
-    ctx.translate(0, -radius*0.85);
-    ctx.rotate(-ang);
-    ctx.fillText(num.toString(), 0, 0);
-    ctx.rotate(ang);
-    ctx.translate(0, radius*0.85);
-    ctx.rotate(-ang);
+  init: function() {
+    this._ctx.setTransform(1, 0, 0, 1, 0, 0);
+    this._ctx.clearRect(0,0, this._canvas.width, this._canvas.height);
+    this._ctx.translate(this._radius, this._radius);
+    this._radius = this._radius * .9;
+    this.drawClock();
+  },
+
+  drawClock: function() {
+    this._drawFace();
+    this._drawNumbers();
+    this._drawTime();
+  },
+
+  _drawFace: function() {
+    this._ctx.beginPath();
+
+    this._ctx.arc(0, 0, this._radius, 0, 2*Math.PI);
+    this._ctx.fillStyle = 'white';
+    this._ctx.fill();
+
+    var grad = this._ctx.createRadialGradient(0,0,this._radius*0.95, 0,0,this._radius*1.05);
+    grad.addColorStop(0, '#333');
+    grad.addColorStop(0.5, 'white');
+    grad.addColorStop(1, '#333');
+    this._ctx.strokeStyle = grad;
+
+    this._ctx.lineWidth = this._radius*0.1;
+    this._ctx.stroke();
+    this._ctx.beginPath();
+    this._ctx.arc(0, 0, this._radius*0.1, 0, 2*Math.PI);
+    this._ctx.fillStyle = '#333';
+    this._ctx.fill();
+  },
+
+  _drawNumbers: function() {
+    this._ctx.font = this._radius*0.15 + "px arial";
+    this._ctx.textBaseline="middle";
+    this._ctx.textAlign="center";
+    for(var num = 1; num < 13; num++){
+      var ang = num * Math.PI / 6;
+      this._ctx.rotate(ang);
+      this._ctx.translate(0, -this._radius*0.85);
+      this._ctx.rotate(-ang);
+      this._ctx.fillText(num.toString(), 0, 0);
+      this._ctx.rotate(ang);
+      this._ctx.translate(0, this._radius*0.85);
+      this._ctx.rotate(-ang);
+    }
+  },
+
+  _drawTime: function() {
+    var hPos = (this._hour * Math.PI / 6) + (this._minute * Math.PI / (6 * 60));
+    this._drawHand(hPos, this._radius * 0.5, this._radius * 0.07);
+
+    var mPos  =(this._minute * Math.PI / 30) + (1 * Math.PI / (30 * 60));
+    this._drawHand(mPos, this._radius * 0.8, this._radius * 0.07);
+  },
+
+  _drawHand: function(pos, l, w) {
+    this._ctx.beginPath();
+    this._ctx.lineWidth = w;
+    this._ctx.lineCap = "round";
+    this._ctx.moveTo(0,0);
+    this._ctx.rotate(pos);
+    this._ctx.lineTo(0, -l);
+    this._ctx.stroke();
+    this._ctx.rotate(-pos);
   }
-}
-
-function drawTime(ctx, radius, hour, minute){
-    var now = new Date();
-    // var hour = now.getHours();
-    // var minute = now.getMinutes();
-    var second = now.getSeconds();
-    //hour
-    hour=hour%12;
-    hour=(hour*Math.PI/6)+
-    (minute*Math.PI/(6*60))+
-    (second*Math.PI/(360*60));
-    drawHand(ctx, hour, radius*0.5, radius*0.07);
-    //minute
-    minute=(minute*Math.PI/30)+(1*Math.PI/(30*60));
-    drawHand(ctx, minute, radius*0.8, radius*0.07);
-    // second
-    second=(second*Math.PI/30);
-    // drawHand(ctx, second, radius*0.9, radius*0.02);
-}
-
-function drawHand(ctx, pos, length, width) {
-    ctx.beginPath();
-    ctx.lineWidth = width;
-    ctx.lineCap = "round";
-    ctx.moveTo(0,0);
-    ctx.rotate(pos);
-    ctx.lineTo(0, -length);
-    ctx.stroke();
-    ctx.rotate(-pos);
-}
 }

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -9,7 +9,7 @@
 
   helpers.asyncConfig().success(function(config) {
     $("#org_name")[0].innerHTML = config.org_name;
-    tz_offset = config.tz_offset;    
+    tz_offset = config.tz_offset;
     location['lat'] = config.lat;
     location['lng'] = config.lng;
   });
@@ -55,7 +55,7 @@
       m_p_time    = helpers.makeMoment(pray_times['maghrib']);
       m_i_time    = moment(m_p_time.add(maghrib_buffer, 'm')).format("h:mm a");
       n_pray_info = helpers.nextPrayerInfo(iqama_times, pray_times, m_i_time);
-      
+
       $("#t_fajr")     .text('Azan: '+pray_times['fajr']);
       $("#t_sunrise")  .text(pray_times['sunrise']);
       $("#t_dhuhr")    .text('Azan: '+pray_times['dhuhr']);
@@ -67,23 +67,23 @@
       $("#i_dhuhr")    .text('Iqama: '+iqama_times['dhuhr']);
       $("#i_asr")      .text('Iqama: '+iqama_times['asr']);
       $("#i_isha")     .text('Iqama: '+iqama_times['isha']);
-      
+
       $("#i_maghrib")  .text('Iqama: '+m_i_time);
 
-      new clock(document.getElementById("canvas_fajr"), iqama_times['fajr'].split(":")[0], iqama_times['fajr'].split(":")[1].split(" ")[0]);
-      new clock(document.getElementById("canvas_sunrise"), pray_times['sunrise'].split(":")[0], pray_times['sunrise'].split(":")[1].split(" ")[0]);
-      new clock(document.getElementById("canvas_dhuhr"), iqama_times['dhuhr'].split(":")[0], iqama_times['dhuhr'].split(":")[1].split(" ")[0]);
-      new clock(document.getElementById("canvas_asr"), iqama_times['asr'].split(":")[0], iqama_times['asr'].split(":")[1].split(" ")[0]);
-      new clock(document.getElementById("canvas_maghrib"), iqama_times['maghrib'].split(":")[0], iqama_times['maghrib'].split(":")[1].split(" ")[0]);
-      new clock(document.getElementById("canvas_isha"), iqama_times['isha'].split(":")[0], iqama_times['isha'].split(":")[1].split(" ")[0]);
+      new Clock(document.getElementById("canvas_fajr"), iqama_times['fajr'].split(":")[0], iqama_times['fajr'].split(":")[1].split(" ")[0]);
+      new Clock(document.getElementById("canvas_sunrise"), pray_times['sunrise'].split(":")[0], pray_times['sunrise'].split(":")[1].split(" ")[0]);
+      new Clock(document.getElementById("canvas_dhuhr"), iqama_times['dhuhr'].split(":")[0], iqama_times['dhuhr'].split(":")[1].split(" ")[0]);
+      new Clock(document.getElementById("canvas_asr"), iqama_times['asr'].split(":")[0], iqama_times['asr'].split(":")[1].split(" ")[0]);
+      new Clock(document.getElementById("canvas_maghrib"), iqama_times['maghrib'].split(":")[0], iqama_times['maghrib'].split(":")[1].split(" ")[0]);
+      new Clock(document.getElementById("canvas_isha"), iqama_times['isha'].split(":")[0], iqama_times['isha'].split(":")[1].split(" ")[0]);
 
     });
-    
+
   }
 
   function updateNextPrayer() {
     if (n_pray_info && iqama_times && pray_times && m_i_time) {
-      n_pray_info = helpers.nextPrayerInfo(iqama_times, pray_times, m_i_time); 
+      n_pray_info = helpers.nextPrayerInfo(iqama_times, pray_times, m_i_time);
       $("#next_prayer").text(n_pray_info['prayer']);
       $("#n_prayer_a") .text(n_pray_info['arabic']);
       $("#athan_mins") .text(n_pray_info['athan']);
@@ -101,8 +101,6 @@
     $('#minute').css("transform", "rotate(" + minute + "deg)");
     $('#second').css("transform", "rotate(" + second + "deg)");
   }
-      
-
 
   function updateDateTime() {
     $("#date").text(moment().format("dddd, MMMM Do YYYY -- iDo iMMMM iYYYY"));


### PR DESCRIPTION
The double rendering issue was a result of creating new `clock` objects on top of the existing ones. We translate the `context` in order to draw from a central point in the rectangle. When we go to draw again, we translate again, but this time to a point that is off the bottom right of the screen. This is why you only see a small portion of a newly drawn clock in the bottom right corner.

The solution is to translate ourselves back to the starting point (top left corner) and make sure our `context` is clear before attempting to draw an updated clock.